### PR TITLE
Add the blacklist creation function to the list of exports

### DIFF
--- a/packages/metro-bundler/src/__tests__/index-test.js
+++ b/packages/metro-bundler/src/__tests__/index-test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @format
+ */
+'use strict';
+
+const metro = require('..');
+
+it('exports the blacklist creator', () => {
+  expect(metro.createBlacklist).toBeDefined();
+});

--- a/packages/metro-bundler/src/index.js
+++ b/packages/metro-bundler/src/index.js
@@ -14,6 +14,7 @@
 const Logger = require('./Logger');
 const TransformCaching = require('./lib/TransformCaching');
 
+const blacklist = require('./blacklist');
 const debug = require('debug');
 const invariant = require('fbjs/lib/invariant');
 
@@ -26,6 +27,7 @@ import type {TransformCache} from './lib/TransformCaching';
 import type {Reporter} from './lib/reporting';
 import type {HasteImpl} from './node-haste/Module';
 
+exports.createBlacklist = blacklist;
 exports.sourceMaps = {fromRawMappings, compactMapping};
 exports.createServer = createServer;
 exports.Logger = Logger;


### PR DESCRIPTION
We use a custom rn-cli.config.js file that specifies a custom blacklist. In addition to blacklisting some of our own directories, we still want to keep RN's default rules for what to blacklist so we also call into the packager's blacklist.

Test Plan: Added a small unit test