### PR TITLE
Add font file extensions (otf and ttf) to default supported extensions

### DIFF
--- a/packages/metro-bundler/src/defaults.js
+++ b/packages/metro-bundler/src/defaults.js
@@ -15,6 +15,7 @@ exports.assetExts = [
   'm4v', 'mov', 'mp4', 'mpeg', 'mpg', 'webm', // Video formats
   'aac', 'aiff', 'caf', 'm4a', 'mp3', 'wav', // Audio formats
   'html', 'pdf', // Document formats
+  'otf', 'ttf', // Font formats
 ];
 
 exports.sourceExts = ['js', 'json'];


### PR DESCRIPTION
This makes it a little more convenient to dynamically load font files. We currently do with help from the "assetExts" config flag and find that we specify it a lot. Would you be interested in taking this PR?

Test Plan: Have tested that with custom native code, we can load otf and ttf files.