### PR TITLE
fix support for node v4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "transform-class-properties",
     "transform-es2015-destructuring",
     "transform-es2015-parameters",
+    "transform-es2015-spread",
     "transform-flow-strip-types",
     "transform-object-rest-spread"
   ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-transform-class-properties": "^6.18.0",
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-es2015-parameters": "^6.23.0",
+    "babel-plugin-transform-es2015-spread": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.21.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015-node": "^6.1.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,6 +17,8 @@
  *  node ./scripts/build.js /user/c/metro-bundler/packages/metro-abc/src/abc.js
  */
 
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
@@ -43,7 +45,7 @@ const babelEs5Options = Object.assign(
   {},
   babelNodeOptions,
   {presets: 'env'},
-  {plugins: [...babelNodeOptions.plugins, 'transform-runtime']}
+  {plugins: [].concat(babelNodeOptions.plugins, 'transform-runtime')}
 );
 
 const fixedWidth = str => {
@@ -87,7 +89,7 @@ function buildFile(file, silent) {
     getPackageName(file),
     'package.json'
   );
-  const {browser} = require(pkgJsonPath);
+  const browser = require(pkgJsonPath).browser;
   if (browser) {
     if (browser.indexOf(BUILD_ES5_DIR) !== 0) {
       throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,7 +521,7 @@ babel-plugin-transform-es2015-shorthand-properties@6.x, babel-plugin-transform-e
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-spread@6.x, babel-plugin-transform-es2015-spread@^6.8.0:
+babel-plugin-transform-es2015-spread@6.x, babel-plugin-transform-es2015-spread@^6.22.0, babel-plugin-transform-es2015-spread@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
   dependencies:


### PR DESCRIPTION
Node v4 support has been broken for some time, with CircleCI failing tests. That's because it needs an additional transform for the spread operator in call position. Ex `foo(...smth)` expanding to `foo.apply(null, smth)`. Also, the build script was using syntax not supported by Node v4.

This changeset fixes the build script, and adds the missing transform. This will be used both for jest test and for the produced production output. This is needed for prod output since we want it to be able to be ran on Node v4 out-of-the-box.

CircleCI will confirm these changes work properly on all supported versions of Node.