### PR TITLE
metro-bundler: tweak babel-register callsite

### DIFF
--- a/packages/metro-bundler/src/babelRegisterOnly.js
+++ b/packages/metro-bundler/src/babelRegisterOnly.js
@@ -13,6 +13,10 @@ require('./setupNodePolyfills');
 var _only = [];
 
 function registerOnly(onlyList) {
+  // This prevents `babel-register` from transforming the code of the
+  // plugins/presets that we are require-ing themselves before setting up the
+  // actual config.
+  require('babel-register')({only: [], babelrc: false});
   require('babel-register')(config(onlyList));
 }
 


### PR DESCRIPTION
This fixes https://github.com/facebook/react-native/issues/14530 on my local repro. The reason the original problem appears is because when requiring the preset itself, what I think is a bug in babel-register kicks in and it starts transforming the presets themselves. That fails because these preset don't actually have the correct transforms plugins installed/specified in their `package.json` (they do it at prepublish time).
