### PR TITLE
Add Content-Length header to *.bundle responses

### DIFF
--- a/packages/metro-bundler/src/Server/__tests__/Server-test.js
+++ b/packages/metro-bundler/src/Server/__tests__/Server-test.js
@@ -116,6 +116,16 @@ describe('processRequest', () => {
     });
   });
 
+  it('returns Content-Length header on request of *.bundle', () => {
+    return makeRequest(
+      requestHandler,
+      'mybundle.bundle?runModule=true'
+    ).then(response => {
+      expect(response.getHeader('Content-Length'))
+        .toBe(Buffer.byteLength(response.body));
+    });
+  });
+
   it('returns 304 on request of *.bundle when if-none-match equals the ETag', () => {
     return makeRequest(
       requestHandler,

--- a/packages/metro-bundler/src/Server/index.js
+++ b/packages/metro-bundler/src/Server/index.js
@@ -769,6 +769,7 @@ class Server {
               mres.writeHead(304);
               mres.end();
             } else {
+              mres.setHeader('Content-Length', Buffer.byteLength(bundleSource));
               mres.end(bundleSource);
             }
             debug('Finished response');


### PR DESCRIPTION
The main goal of this is to be able to show bundle download progress in a follow up PR for react-native.

**Test plan**
Tested that it is possible to show bundle download progress in react-native using this header and added unit test.