### PR TITLE
fix inner yarn.lock

### DIFF
--- a/packages/metro-bundler/yarn.lock
+++ b/packages/metro-bundler/yarn.lock
@@ -306,7 +306,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.8.0:
 
 babel-plugin-transform-es2015-block-scoping@^6.5.0, babel-plugin-transform-es2015-block-scoping@^6.8.0:
   version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz#3bfdcfec318d46df22525cdea88f1978813653af"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz#3bfdcfec318d46df22525cdea88f1978813653af"
   dependencies:
     babel-runtime "^6.9.0"
     babel-template "^6.15.0"


### PR DESCRIPTION
I corrupted the yarn.lock when trying to downgrade that module. This change brings the correct resolution in the `yarn.lock`.