### PR TITLE
Cherry-pick `enableBabelRCLookup` option into 0.10

### DIFF
--- a/packages/metro-bundler/src/Bundler/__tests__/Bundler-test.js
+++ b/packages/metro-bundler/src/Bundler/__tests__/Bundler-test.js
@@ -41,6 +41,7 @@ var commonOptions = {
   allowBundleUpdates: false,
   assetExts: defaults.assetExts,
   cacheVersion: 'smth',
+  enableBabelRCLookup: true,
   extraNodeModules: {},
   platforms: defaults.platforms,
   resetCache: false,
@@ -176,6 +177,7 @@ describe('Bundler', function() {
             minify: false,
             platform: undefined,
             transform: {
+              enableBabelRCLookup: true,
               dev: true,
               generateSourceMaps: false,
               hot: false,

--- a/packages/metro-bundler/src/Bundler/index.js
+++ b/packages/metro-bundler/src/Bundler/index.js
@@ -124,6 +124,7 @@ type Options = {|
   +assetServer: AssetServer,
   +blacklistRE?: RegExp,
   +cacheVersion: string,
+  +enableBabelRCLookup: boolean,
   +extraNodeModules: {},
   +getPolyfills: ({platform: ?string}) => $ReadOnlyArray<string>,
   +getTransformOptions?: GetTransformOptions,
@@ -545,6 +546,7 @@ class Bundler {
     return this.getTransformOptions(
       entryFile,
       {
+        enableBabelRCLookup: this._opts.enableBabelRCLookup,
         dev,
         generateSourceMaps,
         hot,
@@ -587,6 +589,7 @@ class Bundler {
     const bundlingOptions: BundlingOptions = await this.getTransformOptions(
       entryFile,
       {
+        enableBabelRCLookup: this._opts.enableBabelRCLookup,
         dev,
         platform,
         hot,
@@ -797,6 +800,7 @@ class Bundler {
   async getTransformOptions(
     mainModuleName: string,
     options: {|
+      enableBabelRCLookup: boolean,
       dev: boolean,
       generateSourceMaps: boolean,
       hot: boolean,
@@ -822,6 +826,7 @@ class Bundler {
         minify: options.minify,
         platform,
         transform: {
+          enableBabelRCLookup: options.enableBabelRCLookup,
           dev,
           generateSourceMaps: options.generateSourceMaps,
           hot,

--- a/packages/metro-bundler/src/JSTransformer/worker/index.js
+++ b/packages/metro-bundler/src/JSTransformer/worker/index.js
@@ -43,6 +43,7 @@ export type Transformer<ExtraOptions: {} = {}> = {
 };
 
 export type TransformOptionsStrict = {|
+  +enableBabelRCLookup: boolean,
   +dev: boolean,
   +generateSourceMaps: boolean,
   +hot: boolean,
@@ -52,6 +53,7 @@ export type TransformOptionsStrict = {|
 |};
 
 export type TransformOptions = {
+  +enableBabelRCLookup?: boolean,
   +dev?: boolean,
   +generateSourceMaps?: boolean,
   +hot?: boolean,

--- a/packages/metro-bundler/src/Server/index.js
+++ b/packages/metro-bundler/src/Server/index.js
@@ -70,6 +70,7 @@ type Options = {
   assetExts?: Array<string>,
   blacklistRE?: RegExp,
   cacheVersion?: string,
+  enableBabelRCLookup?: boolean,
   extraNodeModules?: {},
   getPolyfills: ({platform: ?string}) => $ReadOnlyArray<string>,
   getTransformOptions?: GetTransformOptions,
@@ -131,6 +132,7 @@ class Server {
     assetExts: Array<string>,
     blacklistRE: void | RegExp,
     cacheVersion: string,
+    enableBabelRCLookup: boolean,
     extraNodeModules: {},
     getPolyfills: ({platform: ?string}) => $ReadOnlyArray<string>,
     getTransformOptions?: GetTransformOptions,
@@ -176,6 +178,10 @@ class Server {
       assetExts: options.assetExts || defaults.assetExts,
       blacklistRE: options.blacklistRE,
       cacheVersion: options.cacheVersion || '1.0',
+      enableBabelRCLookup:
+        options.enableBabelRCLookup != null
+          ? options.enableBabelRCLookup
+          : true,
       extraNodeModules: options.extraNodeModules || {},
       getPolyfills: options.getPolyfills,
       getTransformOptions: options.getTransformOptions,

--- a/packages/metro-bundler/src/index.js
+++ b/packages/metro-bundler/src/index.js
@@ -36,6 +36,7 @@ type Options = {|
   +sourceExts: ?Array<string>,
   +transformCache: TransformCache,
   +transformModulePath: string,
+  enableBabelRCLookup?: boolean,
   getPolyfills: ({platform: ?string}) => $ReadOnlyArray<string>,
   globalTransformCache: ?GlobalTransformCache,
   hasteImpl?: HasteImpl,

--- a/packages/metro-bundler/src/transformer.js
+++ b/packages/metro-bundler/src/transformer.js
@@ -87,6 +87,9 @@ function buildBabelConfig(filename, options) {
   const babelRC = getBabelRC(options.projectRoot);
 
   const extraConfig = {
+    babelrc: typeof options.enableBabelRCLookup === 'boolean'
+      ? options.enableBabelRCLookup
+      : true,
     code: false,
     filename,
   };


### PR DESCRIPTION
This just cherry-picks the commit that adds `enableBabelRCLookup` (0f3d7117d434f5b863ad8da08990d7642c912787) into the 0.10 branch. If this looks good and OK for a patch release could you merge and release 0.10.1?