### PR TITLE
Add require.getModules

### DIFF
--- a/packages/metro-bundler/src/Resolver/polyfills/require.js
+++ b/packages/metro-bundler/src/Resolver/polyfills/require.js
@@ -217,6 +217,11 @@ function moduleThrewError(id, error: any) {
 if (__DEV__) {
   require.Systrace = {beginEvent: () => {}, endEvent: () => {}};
 
+  // Useful for optimizing inline requires
+  require.getModules = () => {
+    return modules;
+  };
+
   // HOT MODULE RELOADING
   var createHotReloadingObject = function() {
     const hot: HotModuleReloadingData = {


### PR DESCRIPTION
In order to aid with debugging inline requires we add a method that
will give us the modules.

**Summary**

I was looking for a way to see what modules had been loaded when I was working with inline requires. I had tried using beginEvent on Systrace, but I was worried that there were modules that I might have missed (I'm not certain if all the loaded files are polyfills before the entryFile is invoked for instance). By adding getModules() it simplifies seeing what modules are loaded.

**Test plan**

At the root of my app `index.ios.js`:

```

import App from './App';
import { AppRegistry } from 'react-native';

AppRegistry.registerComponent('App', () => App);

// after 3 seconds the initial app data should have loaded, so lets take a look:
setTimeout(() => {
  console.log(require.getModules());
}, 3000);

```

**NOTE**
If there is a way to get to this easily (via the debugger or some other mechanism) I would be happy to use that instead and add documentation for it.