### PR TITLE
Fixes Platform.OS and process.env.NODE_ENV inlining resulting in an invalid AST

### DIFF
--- a/packages/metro-bundler/src/JSTransformer/worker/__tests__/inline-test.js
+++ b/packages/metro-bundler/src/JSTransformer/worker/__tests__/inline-test.js
@@ -294,6 +294,90 @@ describe('inline constants', () => {
     );
   });
 
+  it(`doesn't replace Platform.OS in the code if Platform is the left hand side of an assignment expression`, () => {
+    const code = `function a() {
+      Platform.OS = "test"
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(normalize(code));
+  });
+
+  it('replaces Platform.OS in the code if Platform is the right hand side of an assignment expression', () => {
+    const code = `function a() {
+      var a;
+      a = Platform.OS;
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(
+      normalize(code.replace(/Platform\.OS/, '"ios"')),
+    );
+  });
+
+  it(`doesn't replace React.Platform.OS in the code if Platform is the left hand side of an assignment expression`, () => {
+    const code = `function a() {
+      React.Platform.OS = "test"
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(normalize(code));
+  });
+
+  it('replaces React.Platform.OS in the code if Platform is the right hand side of an assignment expression', () => {
+    const code = `function a() {
+      var a;
+      a = React.Platform.OS;
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(
+      normalize(code.replace(/React\.Platform\.OS/, '"ios"')),
+    );
+  });
+
+  it(`doesn't replace ReactNative.Platform.OS in the code if Platform is the left hand side of an assignment expression`, () => {
+    const code = `function a() {
+      ReactNative.Platform.OS = "test"
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(normalize(code));
+  });
+
+  it('replaces ReactNative.Platform.OS in the code if Platform is the right hand side of an assignment expression', () => {
+    const code = `function a() {
+      var a;
+      a = ReactNative.Platform.OS;
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(
+      normalize(code.replace(/ReactNative\.Platform\.OS/, '"ios"')),
+    );
+  });
+
+  it(`doesn't replace require("React").Platform.OS in the code if Platform is the left hand side of an assignment expression`, () => {
+    const code = `function a() {
+      require("React").Platform.OS = "test"
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(normalize(code));
+  });
+
+  it('replaces require("React").Platform.OS in the code if Platform is the right hand side of an assignment expression', () => {
+    const code = `function a() {
+      var a;
+      a = require("React").Platform.OS;
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {platform: 'ios'});
+
+    expect(toString(ast)).toEqual(
+      normalize(code.replace(/require\("React"\)\.Platform\.OS/, '"ios"')),
+    );
+  });
+
   it('replaces non-existing properties with `undefined`', () => {
     const code = 'var a = Platform.select({ios: 1, android: 2})';
     const {ast} = inline('arbitrary.js', {code}, {platform: 'doesnotexist'});
@@ -308,6 +392,25 @@ describe('inline constants', () => {
         return require('Prod');
       }
       return require('Dev');
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {dev: false});
+    expect(toString(ast)).toEqual(
+      normalize(code.replace(/process\.env\.NODE_ENV/, '"production"')),
+    );
+  });
+
+  it(`doesn't replace process.env.NODE_ENV in the code if NODE_ENV is the right hand side of an assignment expression`, () => {
+    const code = `function a() {
+      process.env.NODE_ENV = 'production';
+    }`;
+    const {ast} = inline('arbitrary.js', {code}, {dev: false});
+    expect(toString(ast)).toEqual(normalize(code));
+  });
+
+  it('replaces process.env.NODE_ENV in the code if NODE_ENV is the right hand side of an assignment expression', () => {
+    const code = `function a() {
+      var env;
+      env = process.env.NODE_ENV;
     }`;
     const {ast} = inline('arbitrary.js', {code}, {dev: false});
     expect(toString(ast)).toEqual(


### PR DESCRIPTION
Resolves https://github.com/facebook/metro-bundler/issues/27

**Summary**

There is an edge case where tools like react-primitives need to assign to `Platform.OS`,
but the inline transformation results in an invalid AST.

When Platform.OS is unconditionally inlined, the following scenario: 
````
Platform.OS = 'ios';
````
Is transformed to: 
```
"ios"="ios"
````

And results in error `Property left of AssignmentExpression expected node to be of a type ["LVal"] but instead got "StringLiteral"**`.

See issue in react-primitives: https://github.com/lelandrichardson/react-primitives/issues/79

This patch checks whether the current node is on the left hand side of an AssignmentExpression
and skips the inlining when this is the case.

It also does the same for `process.env.NODE_ENV`, which suffers from the same problem. See related closed issue https://github.com/facebook/react-native/issues/7607#issuecomment-221425153 which was resolved by using bracket notation `process.env["NODE_ENV"]` instead.

**Test plan**

Unit tests included.

**Notes**

This is my first contribution to Metro, and haven't worked with Babel AST a lot, so constructive feedback on the implementation is welcome.
