### PR TITLE
TransformCaching: fix GC condition judgement error

### DIFF
--- a/packages/metro-bundler/src/lib/TransformCaching.js
+++ b/packages/metro-bundler/src/lib/TransformCaching.js
@@ -272,7 +272,7 @@ class FileBasedCache {
     );
     if (
       Number.isInteger(lastCollected) &&
-      Date.now() - lastCollected > GARBAGE_COLLECTION_PERIOD
+      Date.now() - lastCollected < GARBAGE_COLLECTION_PERIOD
     ) {
       return;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I am sending this PR to fix an error in TransformCaching module. See this issue [TransformCaching module try to collect cache every time I build bundle #46](https://github.com/facebook/metro-bundler/issues/46).

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```
/**
   * When restarting packager we want to avoid running the collection over
   * again, so we store the last collection time in a file and we check that
   * first.
   */
  _collectCacheIfOldSync() {
    const {_rootPath} = this;
    const cacheCollectionFilePath = path.join(_rootPath, 'last_collected');
    const lastCollected = Number.parseInt(
      tryReadFileSync(cacheCollectionFilePath) || '',
      10,
    );
    if (
      Number.isInteger(lastCollected) &&
      Date.now() - lastCollected < GARBAGE_COLLECTION_PERIOD
    ) {
      return;
    }
    const effectiveCacheDirPath = path.join(_rootPath, CACHE_SUB_DIR);
    mkdirp.sync(effectiveCacheDirPath);
    collectCacheSync(effectiveCacheDirPath);
    fs.writeFileSync(cacheCollectionFilePath, Date.now().toString());
  }
```
Steps:
1. Create a new react-native project.
2. Put your breakpoint at this sentence `collectCacheSync(effectiveCacheDirPath);`. 
3. Bundle the project, program will break at `collectCacheSync(effectiveCacheDirPath);`
4. Resume the program, finish the first time bundle.
5. Bundle again, this time program won't break.
