### PR TITLE
Add version to .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,3 +13,6 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 unsafe.enable_getters_and_setters=true
 munge_underscores=true
+
+[version]
+^0.48.0


### PR DESCRIPTION
**Summary**

Without this editors or a globally installed flow would use the latest version.
This ensures that flow uses the right version when checking the code.

**Test plan**
```
$ flow
```