### PR TITLE
Fix importing a dot file from the root directory doesn't work

### DIFF
--- a/packages/metro-bundler/src/node-haste/lib/toLocalPath.js
+++ b/packages/metro-bundler/src/node-haste/lib/toLocalPath.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const {relative} = require('path');
+const {relative, basename} = require('path');
 
 declare class OpaqueLocalPath {}
 export type LocalPath = OpaqueLocalPath & string;
@@ -25,7 +25,7 @@ function toLocalPath(
 ): LocalPath {
   for (let i = 0; i < roots.length; i++) {
     const localPath = relative(roots[i], absolutePath);
-    if (localPath[0] !== '.') {
+    if (localPath[0] !== '.' || basename(absolutePath) == localPath) {
       return (localPath: any);
     }
   }


### PR DESCRIPTION
Hi, 
**Summary**
This fixes #40 where bundler cannot resolve a file starting with `.` from the root package directory.

it just adds a check to see if the absolute path filename is the same as the localpath filename then lets it through.

**Test plan**
- Steps to reproduce have been written up in #40

Thanks!
