### PR TITLE
Support `.mjs` as file extension for es modules

### DIFF
--- a/packages/metro-bundler/src/defaults.js
+++ b/packages/metro-bundler/src/defaults.js
@@ -43,7 +43,7 @@ exports.assetExts = [
   'ttf',
 ];
 
-exports.sourceExts = ['js', 'json'];
+exports.sourceExts = ['js', 'json', 'mjs'];
 
 exports.moduleSystem = require.resolve('./Resolver/polyfills/require.js');
 


### PR DESCRIPTION
**Summary**

Support `.mjs` as file extension for es modules assuming they have been transpiled properly that is, like webpack does.

Example setup: https://github.com/mobxjs/mobx/pull/1131/files

Should solve #59

Beyond that I

**Test plan**

I have no clue what I am doing, nor do I have any experience with RN so this is just a proposal :grin:

Testing can be done by dropping the following to files in `<modules folder>/mjstest`

```
package.json

{
   "version": "1.0.0",
   "name": "mjstest"
   "module": "index.mjs"
}

index.mjs

function log() {
  console.log("hello from .mjs")
}

export { log }
```

and than in an app use it:

```
import { log } from "mjstest"

log() // should log something
```

I realize this is the most pathetic attempt of a PR ever. So feel free to close it, but I hope it might have some use as a starting point for support the `.mjs` extension :)