### PR TITLE
Chore: resolve lint errors

### DIFF
--- a/packages/metro-bundler/src/Bundler/source-map/source-map.js
+++ b/packages/metro-bundler/src/Bundler/source-map/source-map.js
@@ -14,7 +14,6 @@
 
 const Generator = require('./Generator');
 
-import type ModuleTransport from '../../lib/ModuleTransport';
 import type {RawMapping as BabelRawMapping} from 'babel-generator';
 
 type GeneratedCodeMapping = [number, number];

--- a/packages/metro-bundler/src/ModuleGraph/worker/__tests__/wrap-worker-fn-test.js
+++ b/packages/metro-bundler/src/ModuleGraph/worker/__tests__/wrap-worker-fn-test.js
@@ -18,8 +18,6 @@ const wrapWorkerFn = require('../wrap-worker-fn');
 const {dirname} = require('path');
 const {fn} = require('../../test-helpers');
 
-const {any} = jasmine;
-
 describe('wrapWorkerFn:', () => {
   const infile = '/arbitrary/in/file';
   const outfile = '/arbitrary/in/file';

--- a/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
+++ b/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
@@ -16,7 +16,6 @@ jest.useRealTimers();
 
 jest.mock('path');
 
-const {join: pathJoin} = require.requireActual('path');
 const DependencyGraph = jest.fn();
 jest.setMock('../../node-haste/DependencyGraph', DependencyGraph);
 let Module;
@@ -219,14 +218,14 @@ describe('Resolver', function() {
       const module = createModule('test module', ['x', 'y']);
       const resolutionResponse = new ResolutionResponseMock({
         dependencies: [module],
-        mainModuleId: 'test module',
+        mainModuleId: 'test module'
       });
 
       resolutionResponse.getResolvedDependencyPairs = module => {
         return [
           ['x', createModule('changed')],
           ['y', createModule('Y')],
-          ['abc', createModule('abc')],
+          ['abc', createModule('abc')]
         ];
       };
 
@@ -237,9 +236,9 @@ describe('Resolver', function() {
             importId,
             padRight(
               resolutionResponse.getModuleId(module),
-              importId.length + 2,
-            ),
-          ]),
+              importId.length + 2
+            )
+          ])
       );
 
       const {code: processedCode} = depResolver.wrapModule({
@@ -249,7 +248,7 @@ describe('Resolver', function() {
         name: 'test module',
         code,
         dependencyOffsets,
-        dev: false,
+        dev: false
       });
 
       expect(processedCode).toEqual(
@@ -260,15 +259,15 @@ describe('Resolver', function() {
               .get('x')
               .trim()} = x`,
           `require(${moduleIds.get('y')});require(${moduleIds.get(
-            'abc',
+            'abc'
           )}); // ${moduleIds.get('abc').trim()} = abc // ${moduleIds
             .get('y')
             .trim()} = y`,
           "require( 'z' )",
           'require( "a")',
           'require("b" )',
-          `}, ${resolutionResponse.getModuleId(module)});`,
-        ].join('\n'),
+          `}, ${resolutionResponse.getModuleId(module)});`
+        ].join('\n')
       );
     });
 
@@ -279,7 +278,7 @@ describe('Resolver', function() {
       const code = 'arbitrary(code)';
       const resolutionResponse = new ResolutionResponseMock({
         dependencies: [module],
-        mainModuleId: 'test module',
+        mainModuleId: 'test module'
       });
 
       const {code: processedCode} = depResolver.wrapModule({
@@ -288,14 +287,14 @@ describe('Resolver', function() {
         code,
         module,
         name: 'test module',
-        dev: true,
+        dev: true
       });
       expect(processedCode).toEqual(
         [
           '__d(/* test module */function(global, require, module, exports) {' +
             code,
-          `}, ${resolutionResponse.getModuleId(module)}, null, "test module");`,
-        ].join('\n'),
+          `}, ${resolutionResponse.getModuleId(module)}, null, "test module");`
+        ].join('\n')
       );
     });
 
@@ -304,7 +303,7 @@ describe('Resolver', function() {
       const module = createModule('test module');
       const resolutionResponse = new ResolutionResponseMock({
         dependencies: [module],
-        mainModuleId: 'test module',
+        mainModuleId: 'test module'
       });
       const inputMap = {version: 3, mappings: 'ARBITRARY'};
 
@@ -314,7 +313,7 @@ describe('Resolver', function() {
         module,
         name: 'test module',
         code: 'arbitrary(code)',
-        map: inputMap,
+        map: inputMap
       });
       expect(map).toBe(inputMap);
     });
@@ -322,14 +321,14 @@ describe('Resolver', function() {
     it('should resolve polyfills', async function() {
       expect.assertions(1);
       return Resolver.load({
-        projectRoot: '/root',
+        projectRoot: '/root'
       }).then(depResolver => {
         const polyfill = createPolyfill('test polyfill', []);
         const code = ['global.fetch = () => 1;'].join('');
 
         const {code: processedCode} = depResolver.wrapModule({
           module: polyfill,
-          code,
+          code
         });
 
         expect(processedCode).toEqual(
@@ -337,8 +336,8 @@ describe('Resolver', function() {
             '(function(global) {',
             'global.fetch = () => 1;',
             '\n})' +
-              "(typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : this);",
-          ].join(''),
+              "(typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : this);"
+          ].join('')
         );
       });
     });
@@ -354,7 +353,7 @@ describe('Resolver', function() {
           module = createJsonModule(id);
           resolutionResponse = new ResolutionResponseMock({
             dependencies: [module],
-            mainModuleId: id,
+            mainModuleId: id
           });
         });
       });
@@ -364,21 +363,21 @@ describe('Resolver', function() {
         const {code: processedCode} = depResolver.wrapModule({
           getModuleId: resolutionResponse.getModuleId,
           dependencyPairs: resolutionResponse.getResolvedDependencyPairs(
-            module,
+            module
           ),
           module,
           name: id,
           code,
-          dev: false,
+          dev: false
         });
 
         expect(processedCode).toEqual(
           [
             `__d(/* ${id} */function(global, require, module, exports) {`,
             `module.exports = ${code}\n}, ${resolutionResponse.getModuleId(
-              module,
-            )});`,
-          ].join(''),
+              module
+            )});`
+          ].join('')
         );
       });
     });
@@ -390,19 +389,19 @@ describe('Resolver', function() {
 
       beforeEach(() => {
         minifyCode = jest.fn((filename, code, map) =>
-          Promise.resolve({code, map}),
+          Promise.resolve({code, map})
         );
         module = createModule(id);
         module.path = '/arbitrary/path.js';
         resolutionResponse = new ResolutionResponseMock({
           dependencies: [module],
-          mainModuleId: id,
+          mainModuleId: id
         });
         sourceMap = {version: 3, sources: ['input'], mappings: 'whatever'};
         return Resolver.load({
           projectRoot: '/root',
           minifyCode,
-          postMinifyProcess: e => e,
+          postMinifyProcess: e => e
         }).then(r => {
           depResolver = r;
         });
@@ -413,13 +412,13 @@ describe('Resolver', function() {
         const minifiedCode = 'minified(code)';
         const minifiedMap = {version: 3, file: ['minified']};
         minifyCode.mockReturnValue(
-          Promise.resolve({code: minifiedCode, map: minifiedMap}),
+          Promise.resolve({code: minifiedCode, map: minifiedMap})
         );
         return depResolver
           .minifyModule({
             path: module.path,
             name: id,
-            code,
+            code
           })
           .then(({code, map}) => {
             expect(code).toEqual(minifiedCode);

--- a/packages/metro-bundler/src/Server/index.js
+++ b/packages/metro-bundler/src/Server/index.js
@@ -17,7 +17,6 @@ const Bundler = require('../Bundler');
 const DeltaBundler = require('../DeltaBundler');
 const MultipartResponse = require('./MultipartResponse');
 
-const crypto = require('crypto');
 const debug = require('debug')('Metro:Server');
 const defaults = require('../defaults');
 const emptyFunction = require('fbjs/lib/emptyFunction');

--- a/packages/metro-bundler/src/lib/TerminalReporter.js
+++ b/packages/metro-bundler/src/lib/TerminalReporter.js
@@ -192,7 +192,7 @@ class TerminalReporter {
     if (error.code === 'EADDRINUSE') {
       this.terminal.log(
         chalk.bgRed.bold(' ERROR '),
-        chalk.red('Metro Bundler can\'t listen on port', chalk.bold(port)),
+        chalk.red("Metro Bundler can't listen on port", chalk.bold(port)),
       );
       this.terminal.log(
         'Most likely another process is already using this port',

--- a/packages/metro-bundler/src/node-haste/DependencyGraph.js
+++ b/packages/metro-bundler/src/node-haste/DependencyGraph.js
@@ -126,9 +126,11 @@ class DependencyGraph extends EventEmitter {
     opts.reporter.update({type: 'dep_graph_loading'});
     const haste = DependencyGraph._createHaste(opts);
     const {hasteFS, moduleMap} = await haste.build();
-    log(createActionEndEntry(log(
-      createActionStartEntry('Initializing Metro Bundler'),
-    )));
+    log(
+      createActionEndEntry(
+        log(createActionStartEntry('Initializing Metro Bundler')),
+      ),
+    );
     opts.reporter.update({type: 'dep_graph_loaded'});
     return new DependencyGraph({
       haste,

--- a/packages/metro-bundler/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packages/metro-bundler/src/node-haste/__tests__/DependencyGraph-test.js
@@ -49,7 +49,6 @@ beforeEach(() => {
 
 describe('DependencyGraph', function() {
   let Module;
-  let ResolutionRequest;
   let defaults;
   let emptyTransformOptions;
 
@@ -93,7 +92,7 @@ describe('DependencyGraph', function() {
     jest.resetModules();
 
     Module = require('../Module');
-    ResolutionRequest = require('../DependencyGraph/ResolutionRequest');
+    require('../DependencyGraph/ResolutionRequest');
 
     emptyTransformOptions = {transformer: {transform: {}}};
     defaults = {
@@ -1095,7 +1094,6 @@ describe('DependencyGraph', function() {
       // FIXME: This is broken, jest-haste-map does not fatal on modules with
       // the same name, because not fataling was required for supporting some
       // OSS projects. We'd like to enable it someday.
-
       //try {
       await processDgraph(opts, async dgraph => {});
       //   throw new Error('should be unreachable');
@@ -1273,10 +1271,8 @@ describe('DependencyGraph', function() {
         json[fieldName] = json.browser;
         delete json.browser;
       }
-
       return json;
     }
-
     function testBrowserField(fieldName) {
       it(
         'should support simple browser field in packages ("' + fieldName + '")',
@@ -2097,7 +2093,6 @@ describe('DependencyGraph', function() {
         },
       );
     }
-
     it('should fall back to browser mapping from react-native mapping', async () => {
       var root = '/root';
       setMockFileSystem({
@@ -5451,7 +5446,6 @@ describe('DependencyGraph', function() {
         dependencies.map(d => `require(${JSON.stringify(d)});`).join('\n')
       );
     }
-
     function getDependencies() {
       return dependencyGraph.getDependencies({
         entryPath: '/root/index.js',
@@ -5459,7 +5453,6 @@ describe('DependencyGraph', function() {
         options: emptyTransformOptions,
       });
     }
-
     beforeEach(function() {
       onProgress = jest.genMockFn();
       setMockFileSystem({
@@ -5590,7 +5583,6 @@ describe('DependencyGraph', function() {
           }
           return deferred.promise;
         }
-
         return returnValue;
       });
     });
@@ -5705,8 +5697,11 @@ describe('DependencyGraph', function() {
    * When running a test on the dependency graph, watch mode is enabled by
    * default, so we must end the watcher to ensure the test does not hang up
    * (regardless if the test passes or fails).
-   */
-  async function processDgraphFor(DependencyGraph, options, processor) {
+   */ async function processDgraphFor(
+    DependencyGraph,
+    options,
+    processor,
+  ) {
     const dgraph = await DependencyGraph.load(options);
     try {
       await processor(dgraph);
@@ -5714,7 +5709,6 @@ describe('DependencyGraph', function() {
       dgraph.end();
     }
   }
-
   function defer(value) {
     let resolve;
     const promise = new Promise(r => {
@@ -5722,11 +5716,9 @@ describe('DependencyGraph', function() {
     });
     return {promise, resolve: () => resolve(value)};
   }
-
   function setMockFileSystem(object) {
     return require('fs').__setMockFilesystem(object);
   }
-
   function triggerAndProcessWatchEvent(dgraphPromise, eventType, filename) {
     return Promise.resolve(dgraphPromise).then(
       dgraph =>
@@ -5736,7 +5728,6 @@ describe('DependencyGraph', function() {
         }),
     );
   }
-
   function triggerWatchEvent(eventType, filename) {
     return require('fs').__triggerWatchEvent(eventType, filename);
   }


### PR DESCRIPTION
**Summary**

Ran `yarn lint-fix` and got these updates. Also fixed 5 ESLint warnings.
Need these in place for builds to pass.

**Test plan**

Run `yarn lint` and expect it to pass without errors.