### PR TITLE
Exempt Resolver/polyfills/require.js from extract-dependencies

### DIFF
--- a/packages/metro-bundler/src/JSTransformer/worker/index.js
+++ b/packages/metro-bundler/src/JSTransformer/worker/index.js
@@ -18,6 +18,7 @@ const extractDependencies = require('./extract-dependencies');
 const inline = require('./inline');
 const invariant = require('fbjs/lib/invariant');
 const minify = require('./minify');
+const path = require('path')
 
 import type {LogEntry} from '../../Logger/Types';
 import type {MappingsMap} from '../../lib/SourceMap';
@@ -85,6 +86,11 @@ type TransformCode = (
   Callback<Data>,
 ) => void;
 
+const pathToRequirePolyfill = path.resolve(
+  __dirname,
+  '../../Resolver/polyfills/require.js'
+)
+
 const transformCode: TransformCode = asyncify(
   (
     transformer: Transformer<*>,
@@ -141,8 +147,8 @@ const transformCode: TransformCode = asyncify(
       code = code.replace(/^#!.*/, '');
     }
 
-    const depsResult = isJson
-      ? {dependencies: [], dependencyOffsets: []}
+    const depsResult = isJson || filename === pathToRequirePolyfill
+      ? { dependencies: [], dependencyOffsets: [] }
       : extractDependencies(code);
 
     const timeDelta = process.hrtime(


### PR DESCRIPTION
**Summary**

`metro-bundler/src/JSTransformer/worker/extract-dependencies.js` parses every file to gather the usage of `require(...)` and extract the module name for building the dependency array.

The problem is that `exract-depdendencies.js` additionally analyzes `metro-bundler/src/Resolver/polyfills/require.js` which includes `require(moduleId)`. So it's failing every single time because `moduleId` is an `Identifier` (variable) instead of a `StringLiteral` as required in `extract-dependencies.js`.

Fixes #65

**Test plan**

Generate a successful build as normal.
