### PR TITLE
Prevent error on safely-handled requires using non-static arguments

### DIFF
--- a/packages/metro-bundler/src/JSTransformer/worker/__tests__/extract-dependencies-test.js
+++ b/packages/metro-bundler/src/JSTransformer/worker/__tests__/extract-dependencies-test.js
@@ -102,6 +102,22 @@ describe('Dependency extraction:', () => {
     );
   });
 
+  it('throws on calls to require with non-static arguments, nested deeper than one level inside of a try block', () => {
+    const code = "try { if (1) { require('foo/' + bar) } } catch (e) { }";
+
+    expect(() => extractDependencies(code)).toThrowError(
+      'require() must have a single string literal argument',
+    );
+  });
+
+  it('does not throw on calls to require with non-static arguments, nested directly inside of a try block', () => {
+    const code = "try { require('foo/' + bar) } catch (e) { }";
+
+    const {dependencies, dependencyOffsets} = extractDependencies(code);
+    expect(dependencies).toEqual([]);
+    expect(dependencyOffsets).toEqual([]);
+  });
+
   it('does not get confused by previous states', () => {
     // yes, this was a bug
     const code = 'require("a");/* a comment */ var a = /[a]/.test(\'a\');';


### PR DESCRIPTION
**Summary**
This is the workaround that @cpojer suggested in #65 and should resolve the biggest pain point that developers are experiencing in that issue: using moment.js in React Native. Hopefully this at least serves as a starting point to reaching a decent solution for libraries using non-static `require()` statements.

**Test plan**
##### 1. Two unit tests added:
- Expected error when non-static-argument-based `require()` is nested more than one level deep within a `try` statement
- Expected no error when non-static-argument-based `require()` is nested directly within a `try` statement

##### 2. Ran the following command and got a clean bundle:
```bash
ip-192-168-1-10:trueflipapp richard$ react-native bundle --entry-file index.js --platform ios --bundle-output /tmp/test.js --reset-cache
Scanning folders for symlinks in /repo/trueflip/sandbox/code/trueflipapp/node_modules (8ms)
Scanning folders for symlinks in /repo/trueflip/sandbox/code/trueflipapp/node_modules (8ms)
Loading dependency graph, done.
warning: the transform cache was reset.
bundle: start
bundle: finish
bundle: Writing bundle output to: /tmp/test.js
bundle: Done writing bundle output
```

##### 3. Added the updates to a `yarn link`ed metro-bundle locally and successfully loaded my react native app w/ moment.js as a dependency.
