### PR TITLE
Whitelist node opt --max-old-space-size for JSTransformer

### DIFF
--- a/packages/metro-bundler/src/JSTransformer/index.js
+++ b/packages/metro-bundler/src/JSTransformer/index.js
@@ -61,7 +61,8 @@ function makeFarm(worker, methods, timeout, maxConcurrentWorkers) {
       execArgv: process.execArgv.filter(
         arg =>
           /^--stack[_-]trace[_-]limit=[0-9]+$/.test(arg) ||
-          /^--heap[_-]growing[_-]percent=[0-9]+$/.test(arg),
+          /^--heap[_-]growing[_-]percent=[0-9]+$/.test(arg) ||
+          /^--max[_-]old[_-]space[_-]size=[0-9]+$/.test(arg)
       ),
       maxConcurrentCallsPerWorker: 1,
       maxConcurrentWorkers,


### PR DESCRIPTION
Whitelist node opt `--max-old-space-size` for JSTransformer.

Bundling can choke on the default node memory settings for those of us generating large index.js files. This change allows supplied node options to make it through to the node processes spawned by the JSTransformer worker farm.

