### PR TITLE
Upgrade uglify-es to fix minification issues

### DIFF
--- a/packages/metro-bundler/package.json
+++ b/packages/metro-bundler/package.json
@@ -44,7 +44,7 @@
     "source-map": "^0.5.6",
     "temp": "0.8.3",
     "throat": "^4.1.0",
-    "uglify-es": "^3.1.0",
+    "uglify-es": "^3.1.8",
     "wordwrap": "^1.0.0",
     "write-file-atomic": "^1.2.0",
     "xpipe": "^1.0.5"


### PR DESCRIPTION
**Summary**

Minification fails or minified bundle may crash due to uglify-es bugs which have been fixed recently. See https://github.com/facebook/react-native/issues/16689

**Test plan**

Try to production bundle a project using ex-navigation, which fails with:
```
Maximum call stack size exceeded
```

Use this patch and see that bundling suceeds. There are also minified runtime errors solved by this change, see https://github.com/facebook/react-native/issues/16689 for more information.