### PR TITLE
Normalize module name to have platform specific folder separators

### DIFF
--- a/packages/metro-bundler/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro-bundler/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -266,7 +266,7 @@ class ModuleResolver<TModule: Moduleish, TPackage: Packageish> {
     const extraSearchQueue = [];
     if (this._options.extraNodeModules) {
       const {extraNodeModules} = this._options;
-      const bits = toModuleName.split(path.sep);
+      const bits = path.normalize(toModuleName).split(path.sep);
       const packageName = bits[0];
       if (extraNodeModules[packageName]) {
         bits[0] = extraNodeModules[packageName];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

It is currently not possible to resolve specific module imports (such as `react-native/Libraries/Image/AssetRegistry` using forward slashes as folder separators) using a custom mapping defined in `extraNodeModules` on Windows. This PR solves this issue by normalizing module names to use platform-specific folder separators before splitting the module name using `path.sep` as separators.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We use `extraNodeModules` to create a mapping between `react-native` and a forked and scoped version of react-native (i.e. `@scope/react-native`). If we import a specific file from react-native (such as [`react-native/Libraries/Image/AssetRegistry`](https://github.com/facebook/react-native/blob/master/local-cli/core/Constants.js), which gets referenced when importing image assets), `ModuleResolution.js` is not able to extract the first folder name on Windows. This first folder name is the name of the module (`react-native` in the previous example) and is used to query `extraNodeModules` for possible matches. It is not able to find this folder name because the module name is split using `path.sep` as a separator, which is `'\\'` on Windows. Most module names use forward slashes as folder separators. The solution is to normalize `toModuleName` before we split on `path.sep`.